### PR TITLE
Fix navigation to root page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:moovup_demo/pages/history_page/history_page.dart';
 import 'package:moovup_demo/pages/saved_job_page/saved_job_page.dart';
 
 import 'package:moovup_demo/repositories/job_repository.dart';
@@ -131,6 +132,7 @@ class _MyAppState extends State<MyApp> {
           JobListPage.routeName: (context) => JobListPage(title: 'Job List'),
           JobDetailPage.routeName: (context) => JobDetailPage("jobId"),
           SavedJobPage.routeName: (context) => SavedJobPage(),
+          HistoryPage.routeName: (context) => HistoryPage(),
           JobSearchPage.routeName: (context) => JobSearchPage(title: "Job Searching", searchCategory: ''),
           SettingPage.routeName: (context) => SettingPage(),
         },

--- a/lib/pages/history_page/history_page.dart
+++ b/lib/pages/history_page/history_page.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
 
-class SettingPage extends StatelessWidget {
-  static const routeName = '/setting';
-  const SettingPage({Key? key}) : super(key: key);
+class HistoryPage extends StatelessWidget {
+  static const routeName = '/history';
+  const HistoryPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Settings'),
+        title: Text('My Applications'),
         leading: IconButton(
           icon: Icon(Icons.arrow_back),
           onPressed:() => Navigator.pop(context, false),
         ),
       ),
-      body: Center(child: Text('Settings', style: Theme.of(context).textTheme.headline5,)),
+      body: Center(child: Text('Applications', style: Theme.of(context).textTheme.headline5,)),
     );
   }
 }

--- a/lib/pages/job_search_page/job_search_page.dart
+++ b/lib/pages/job_search_page/job_search_page.dart
@@ -159,6 +159,10 @@ class _JobSearchPageState extends State<JobSearchPage> {
       child: Scaffold(
         appBar: AppBar(
           title: Text(widget.title),
+          leading: IconButton(
+            icon: Icon(Icons.arrow_back),
+            onPressed: () => Navigator.pop(context, false),
+          ),
         ),
         body: Container(
           child: SingleChildScrollView(

--- a/lib/pages/preference_page/preference_page.dart
+++ b/lib/pages/preference_page/preference_page.dart
@@ -34,6 +34,10 @@ class _PreferencePageState extends State<PreferencePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed:() => Navigator.pop(context, false),
+        ),
       ),
       drawer: AppDrawer(),
       body: SingleChildScrollView(
@@ -61,7 +65,7 @@ class _PreferencePageState extends State<PreferencePage> {
                           child: IconButton(
                             onPressed: () {
                               _bloc.savePreference(state.myPrefList);
-                              Navigator.pushNamed(context, '/');
+                              Navigator.of(context).pushNamedAndRemoveUntil('/', ModalRoute.withName('/'));
                             },
                             iconSize: 40,
                             color: Colors.purple,

--- a/lib/pages/saved_job_page/saved_job_page.dart
+++ b/lib/pages/saved_job_page/saved_job_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:moovup_demo/blocs/BookmarkBloc/bookmark_bloc.dart';
 import 'package:moovup_demo/blocs/BookmarkBloc/bookmark_events.dart';
 import 'package:moovup_demo/blocs/BookmarkBloc/bookmark_states.dart';
+import 'package:moovup_demo/pages/job_search_page/job_search_page.dart';
 import 'package:moovup_demo/widgets/job_card.dart';
 
 class SavedJobPage extends StatefulWidget {
@@ -27,11 +28,11 @@ class _SavedJobPageState extends State<SavedJobPage> {
         title: Text('Saved Jobs'),
         leading: IconButton(
           icon: Icon(Icons.arrow_back),
-          onPressed:() => Navigator.pop(context, false),
+          onPressed: () => Navigator.pop(context, false),
         ),
         actions: [
           IconButton(
-            onPressed: () {},
+            onPressed: () => Navigator.of(context).pushNamed(JobSearchPage.routeName),
             icon: const Icon(Icons.manage_search),
             tooltip: 'Show Search Bar',
           ),

--- a/lib/pages/saved_job_page/saved_job_page.dart
+++ b/lib/pages/saved_job_page/saved_job_page.dart
@@ -25,6 +25,10 @@ class _SavedJobPageState extends State<SavedJobPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Saved Jobs'),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed:() => Navigator.pop(context, false),
+        ),
         actions: [
           IconButton(
             onPressed: () {},

--- a/lib/widgets/category_container.dart
+++ b/lib/widgets/category_container.dart
@@ -8,13 +8,11 @@ class CategoryButton extends StatelessWidget {
 
   CategoryButton(this.catData);
 
-  void selectJobCategory(BuildContext ctx) {
+  void selectJobCategory(BuildContext context) {
     // NOTE: print for implmentation
     // print("catData: ${this.catData}");
-    Navigator.of(ctx).pushNamed(
+    Navigator.of(context).pushNamed(
       JobSearchPage.routeName,
-      arguments: {
-      },
     );
   }
 

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -1,4 +1,7 @@
+
 import 'package:flutter/material.dart';
+import 'package:moovup_demo/pages/history_page/history_page.dart';
+import 'package:moovup_demo/pages/preference_page/preference_page.dart';
 import 'package:moovup_demo/pages/saved_job_page/saved_job_page.dart';
 
 class AppDrawer extends StatelessWidget {
@@ -36,29 +39,21 @@ class AppDrawer extends StatelessWidget {
           ),
           ListTile(
             leading: CircleAvatar(
-              child: Icon(Icons.ac_unit),
-            ),
-            title: Text('Main'),
-            onTap: () {
-              Navigator.pushNamed(context, '/');
-            },
-          ),
-          ListTile(
-            leading: CircleAvatar(
               child: Icon(Icons.alt_route),
             ),
             title: Text('Preference'),
             onTap: () {
-              Navigator.pushNamed(context, '/preference');
+              Navigator.of(context).pushNamed(PreferencePage.routeName);
             },
           ),
           ListTile(
             leading: CircleAvatar(
               child: Icon(Icons.view_list),
             ),
-            title: Text('Job List'),
+            title: Text('My Applications'),
             onTap: () {
-              Navigator.pushNamed(context, '/jobList');
+              Navigator.of(context).pushNamed(HistoryPage.routeName);
+
             },
           ),
           ListTile(
@@ -67,7 +62,8 @@ class AppDrawer extends StatelessWidget {
             ),
             title: Text('Bookmarks'),
             onTap: () {
-              Navigator.pushNamed(context, SavedJobPage.routeName);
+              Navigator.of(context).pushNamed(SavedJobPage.routeName);
+
             },
           ),
           ListTile(

--- a/lib/widgets/job_card.dart
+++ b/lib/widgets/job_card.dart
@@ -7,8 +7,14 @@ class JobCard extends StatelessWidget {
 
   const JobCard({Key? key, required this.job}) : super(key: key);
 
-  void selectJobCard(BuildContext ctx) {
-    Navigator.of(ctx).push(MaterialPageRoute(builder: (context) => JobDetailPage(job['_id'])));
+  void selectJobCard(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => JobDetailPage(
+          job['_id'],
+        ),
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
There was an issue where Page routing is not smoothly done i.e. _new pages are created and added on the stack when open JobListPage on JobListPage, or other pages._ 
1. Now the JobListPage is always over other page on the widget tree. Other pages will pop the current page to go back to jobListPage when back button on the appBar is clicked.